### PR TITLE
Container needs to be position: static

### DIFF
--- a/jquery.nested.js
+++ b/jquery.nested.js
@@ -383,7 +383,10 @@ if (!Object.keys) {
             var self = this;
 
             // set container height
-            this.box.css('height', this._setHeight($els));
+            this.box.css({
+              'height': this._setHeight($els),
+              'position': 'static'
+            });
 
             $els.reverse();
             var speed = this.options.animationOptions.speed;


### PR DESCRIPTION
See what happens if container happens to be position: relativecor anything other than static: http://jsfiddle.net/BdXPL/1/

This could happen if the container has other styles including non-static position. By having the JS overwrite the position, the user can at least know he needs to work around the position and not have to spend half an hour like me trying to see what's fucking up the offset.
