### PR TITLE
Fix for overlapping boxes

### DIFF
--- a/jquery.nested.js
+++ b/jquery.nested.js
@@ -289,7 +289,7 @@ if (!Object.keys) {
 
             while (true) {
 
-                for (var y = col; y >= 0; y--) {
+                for (var y = row; y >= 0; y--) {
                     if (this.gridrow[gridy + y]) break;
                     this.gridrow[gridy + y] = new Object;
                     for (var x = 0; x < this.columns; x++) {


### PR DESCRIPTION
It seems there was a typo when initializing the grid array. This caused some grid cells to not be set as "used" and therefore, caused overlapping later on.
